### PR TITLE
Add introductory content to category pages

### DIFF
--- a/analyse-financiere.html
+++ b/analyse-financiere.html
@@ -2,18 +2,8 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
- codex/set-up-nova-vox-interstellar-static-site-s8siqw
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Nova Vox Interstellar – actualités et analyses EVE Online">
- codex/set-up-nova-vox-interstellar-static-site-3r16vt
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Nova Vox Interstellar – actualités et analyses EVE Online">
- codex/set-up-nova-vox-interstellar-static-site-g0i3pj
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Nova Vox Interstellar – actualités et analyses EVE Online">
- main
- main
- main
   <title>Analyse financière - NVI</title>
   <link rel="stylesheet" href="assets/style.css">
   <script defer src="assets/script.js"></script>
@@ -34,27 +24,17 @@
   </nav>
 </header>
 <main>
- codex/set-up-nova-vox-interstellar-static-site-s8siqw
- codex/set-up-nova-vox-interstellar-static-site-3r16vt
- codex/set-up-nova-vox-interstellar-static-site-g0i3pj
- main
- main
   <section class="hero">
     <img src="assets/images/analyse-financiere.svg" alt="Analyse financière">
     <h2>Analyse financière</h2>
+  </section>
+  <section class="intro">
+    <p>Suivez les fluctuations des marchés d'ISK, des minerais et des plans de recherche. Nos analystes décryptent les tendances économiques qui façonnent l'univers d'EVE Online.</p>
   </section>
   <ul id="category-list" data-category="analyse-financiere" class="posts"></ul>
 </main>
 <footer>
   <p>© 2025 Nova Vox Interstellar</p>
 </footer>
- codex/set-up-nova-vox-interstellar-static-site-s8siqw
- codex/set-up-nova-vox-interstellar-static-site-3r16vt
-  <h2>Analyse financière</h2>
-  <ul id="category-list" data-category="analyse-financiere" class="posts"></ul>
-</main>
- main
- main
- main
 </body>
 </html>

--- a/cartes-batailles.html
+++ b/cartes-batailles.html
@@ -2,18 +2,8 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
- codex/set-up-nova-vox-interstellar-static-site-s8siqw
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Nova Vox Interstellar – actualités et analyses EVE Online">
- codex/set-up-nova-vox-interstellar-static-site-3r16vt
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Nova Vox Interstellar – actualités et analyses EVE Online">
- codex/set-up-nova-vox-interstellar-static-site-g0i3pj
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Nova Vox Interstellar – actualités et analyses EVE Online">
- main
- main
- main
   <title>Cartes & batailles - NVI</title>
   <link rel="stylesheet" href="assets/style.css">
   <script defer src="assets/script.js"></script>
@@ -34,27 +24,17 @@
   </nav>
 </header>
 <main>
- codex/set-up-nova-vox-interstellar-static-site-s8siqw
- codex/set-up-nova-vox-interstellar-static-site-3r16vt
- codex/set-up-nova-vox-interstellar-static-site-g0i3pj
- main
- main
   <section class="hero">
     <img src="assets/images/cartes-batailles.svg" alt="Cartes et batailles">
     <h2>Cartes &amp; batailles</h2>
+  </section>
+  <section class="intro">
+    <p>Explorez les fronts de guerre actifs et les rapports de batailles les plus récents pour planifier vos prochaines campagnes.</p>
   </section>
   <ul id="category-list" data-category="cartes-batailles" class="posts"></ul>
 </main>
 <footer>
   <p>© 2025 Nova Vox Interstellar</p>
 </footer>
- codex/set-up-nova-vox-interstellar-static-site-s8siqw
- codex/set-up-nova-vox-interstellar-static-site-3r16vt
-  <h2>Cartes & batailles</h2>
-  <ul id="category-list" data-category="cartes-batailles" class="posts"></ul>
-</main>
- main
- main
- main
 </body>
 </html>

--- a/edition-semaine.html
+++ b/edition-semaine.html
@@ -2,18 +2,8 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
- codex/set-up-nova-vox-interstellar-static-site-s8siqw
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Nova Vox Interstellar – actualités et analyses EVE Online">
- codex/set-up-nova-vox-interstellar-static-site-3r16vt
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Nova Vox Interstellar – actualités et analyses EVE Online">
- codex/set-up-nova-vox-interstellar-static-site-g0i3pj
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Nova Vox Interstellar – actualités et analyses EVE Online">
- main
- main
- main
   <title>Édition de la semaine - NVI</title>
   <link rel="stylesheet" href="assets/style.css">
   <script defer src="assets/script.js"></script>
@@ -34,27 +24,17 @@
   </nav>
 </header>
 <main>
- codex/set-up-nova-vox-interstellar-static-site-s8siqw
- codex/set-up-nova-vox-interstellar-static-site-3r16vt
- codex/set-up-nova-vox-interstellar-static-site-g0i3pj
- main
- main
   <section class="hero">
     <img src="assets/images/edition-semaine.svg" alt="Édition de la semaine">
     <h2>Édition de la semaine</h2>
+  </section>
+  <section class="intro">
+    <p>Chaque semaine, Nova Vox Interstellar rassemble les nouvelles les plus marquantes de New Eden : guerres d'alliance, découvertes d'artefacts rares et prouesses industrielles.</p>
   </section>
   <ul id="category-list" data-category="edition-semaine" class="posts"></ul>
 </main>
 <footer>
   <p>© 2025 Nova Vox Interstellar</p>
 </footer>
- codex/set-up-nova-vox-interstellar-static-site-s8siqw
- codex/set-up-nova-vox-interstellar-static-site-3r16vt
-  <h2>Édition de la semaine</h2>
-  <ul id="category-list" data-category="edition-semaine" class="posts"></ul>
-</main>
- main
- main
- main
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -2,54 +2,17 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
- codex/set-up-nova-vox-interstellar-static-site-s8siqw
- codex/set-up-nova-vox-interstellar-static-site-3r16vt
- codex/set-up-nova-vox-interstellar-static-site-g0i3pj
- main
- main
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Nova Vox Interstellar – actualités et analyses EVE Online">
-  <title>Nova Vox Interstellar</title>
-  <link rel="stylesheet" href="assets/style.css">
-  <script defer src="assets/script.js"></script>
- codex/set-up-nova-vox-interstellar-static-site-s8siqw
- codex/set-up-nova-vox-interstellar-static-site-3r16vt
-codex/set-up-nova-vox-interstellar-static-site-vuxm5c
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Nova Vox Interstellar – actualités et analyses EVE Online">
   <title>Nova Vox Interstellar</title>
   <link rel="stylesheet" href="assets/void-theme.css">
   <script defer src="assets/stellar-index.js"></script>
-  <title>Nova Vox Interstellar</title>
-codex/set-up-nova-vox-interstellar-static-site-lcxmnz
-  <link rel="stylesheet" href="assets/void-theme.css">
-  <script defer src="assets/stellar-index.js"></script>
- codex/set-up-nova-vox-interstellar-static-site-0v0deg
-  <link rel="stylesheet" href="assets/void-theme.css">
-  <script defer src="assets/stellar-index.js"></script>
-
-  <link rel="stylesheet" href="assets/style.css">
-  <script defer src="assets/script.js"></script>
-main
-main
-main
- main
- main
- main
 </head>
 <body>
 <header>
   <h1>Nova Vox Interstellar</h1>
   <nav>
     <a href="index.html">Accueil</a>
- codex/set-up-nova-vox-interstellar-static-site-s8siqw
- codex/set-up-nova-vox-interstellar-static-site-3r16vt
- codex/set-up-nova-vox-interstellar-static-site-g0i3pj
-codex/set-up-nova-vox-interstellar-static-site-vuxm5c
-codex/set-up-nova-vox-interstellar-static-site-lcxmnz
-codex/set-up-nova-vox-interstellar-static-site-0v0deg
-main
-main
     <a href="archives-stellaires.html">Archives</a>
     <a href="chroniques-hebdo.html">Édition de la semaine</a>
     <a href="oracles-du-marche.html">Analyse financière</a>
@@ -58,9 +21,6 @@ main
     <a href="manifeste.html">À propos</a>
     <a href="transmissions.html">Contact</a>
     <a href="premium-isk.html">Premium</a>
-codex/set-up-nova-vox-interstellar-static-site-vuxm5c
-codex/set-up-nova-vox-interstellar-static-site-lcxmnz
-main
   </nav>
 </header>
 <main>
@@ -68,122 +28,34 @@ main
     <img src="assets/images/hero-frontier.svg" alt="Flotte de vaisseaux de Nova Vox Interstellar">
     <h2>Chroniques galactiques</h2>
   </section>
-codex/set-up-nova-vox-interstellar-static-site-vuxm5c
- main
- main
- main
-    <a href="archives.html">Archives</a>
-    <a href="edition-semaine.html">Édition de la semaine</a>
-    <a href="analyse-financiere.html">Analyse financière</a>
-    <a href="temoignages.html">Témoignages</a>
-    <a href="cartes-batailles.html">Cartes &amp; batailles</a>
-    <a href="a-propos.html">À propos</a>
-    <a href="contact.html">Contact</a>
-    <a href="premium.html">Premium</a>
- codex/set-up-nova-vox-interstellar-static-site-s8siqw
- codex/set-up-nova-vox-interstellar-static-site-3r16vt
- codex/set-up-nova-vox-interstellar-static-site-g0i3pj
- main
- main
-  </nav>
-</header>
-<main>
-  <section class="hero">
-    <img src="assets/images/hero-frontier.svg" alt="Flotte de vaisseaux de Nova Vox Interstellar">
-    <h2>Chroniques galactiques</h2>
-  </section>
- codex/set-up-nova-vox-interstellar-static-site-s8siqw
- codex/set-up-nova-vox-interstellar-static-site-3r16vt
-main
-  </nav>
-</header>
-<main>
-main
-main
- main
- main
- main
   <section id="latest">
     <h2>Dernières publications</h2>
     <ul class="posts"></ul>
   </section>
- codex/set-up-nova-vox-interstellar-static-site-s8siqw
-  <section class="feature-grid">
-    <article class="feature">
-      <a href="edition-semaine.html">
- codex/set-up-nova-vox-interstellar-static-site-3r16vt
-  <section class="feature-grid">
-    <article class="feature">
-      <a href="edition-semaine.html">
- codex/set-up-nova-vox-interstellar-static-site-g0i3pj
-  <section class="feature-grid">
-    <article class="feature">
-      <a href="edition-semaine.html">
-codex/set-up-nova-vox-interstellar-static-site-vuxm5c
-codex/set-up-nova-vox-interstellar-static-site-lcxmnz
-main
   <section class="feature-grid">
     <article class="feature">
       <a href="chroniques-hebdo.html">
- main
- main
- main
         <img src="assets/images/edition-semaine.svg" alt="Édition de la semaine">
         Édition de la semaine
       </a>
     </article>
     <article class="feature">
- codex/set-up-nova-vox-interstellar-static-site-s8siqw
-      <a href="cartes-batailles.html">
- codex/set-up-nova-vox-interstellar-static-site-3r16vt
-      <a href="cartes-batailles.html">
- codex/set-up-nova-vox-interstellar-static-site-g0i3pj
-      <a href="cartes-batailles.html">
       <a href="plans-de-bataille.html">
- main
- main
- main
         <img src="assets/images/cartes-batailles.svg" alt="Cartes et batailles">
         Cartes &amp; batailles
       </a>
     </article>
     <article class="feature">
- codex/set-up-nova-vox-interstellar-static-site-s8siqw
-      <a href="analyse-financiere.html">
- codex/set-up-nova-vox-interstellar-static-site-3r16vt
-      <a href="analyse-financiere.html">
- codex/set-up-nova-vox-interstellar-static-site-g0i3pj
-      <a href="analyse-financiere.html">
       <a href="oracles-du-marche.html">
- main
- main
- main
         <img src="assets/images/analyse-financiere.svg" alt="Analyse financière">
         Analyse financière
       </a>
     </article>
   </section>
- codex/set-up-nova-vox-interstellar-static-site-s8siqw
- codex/set-up-nova-vox-interstellar-static-site-3r16vt
- codex/set-up-nova-vox-interstellar-static-site-g0i3pj
-codex/set-up-nova-vox-interstellar-static-site-vuxm5c
- main
- main
- main
   <section id="category-sections"></section>
 </main>
 <footer>
   <p>© 2025 Nova Vox Interstellar</p>
 </footer>
- codex/set-up-nova-vox-interstellar-static-site-s8siqw
- codex/set-up-nova-vox-interstellar-static-site-3r16vt
- codex/set-up-nova-vox-interstellar-static-site-g0i3pj
-main
-  <section id="category-sections"></section>
-</main>
-main
- main
- main
- main
 </body>
 </html>

--- a/temoignages.html
+++ b/temoignages.html
@@ -2,18 +2,8 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
- codex/set-up-nova-vox-interstellar-static-site-s8siqw
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Nova Vox Interstellar – actualités et analyses EVE Online">
- codex/set-up-nova-vox-interstellar-static-site-3r16vt
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Nova Vox Interstellar – actualités et analyses EVE Online">
- codex/set-up-nova-vox-interstellar-static-site-g0i3pj
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Nova Vox Interstellar – actualités et analyses EVE Online">
- main
- main
- main
   <title>Témoignages - NVI</title>
   <link rel="stylesheet" href="assets/style.css">
   <script defer src="assets/script.js"></script>
@@ -34,23 +24,17 @@
   </nav>
 </header>
 <main>
-  <h2>Témoignages</h2>
+  <section class="hero">
+    <img src="assets/images/fleet-engagement.svg" alt="Témoignages de pilotes">
+    <h2>Témoignages</h2>
+  </section>
+  <section class="intro">
+    <p>Les pilotes partagent ici leurs récits de gloire, de pertes et d'amitiés forgées dans le vide intersidéral.</p>
+  </section>
   <ul id="category-list" data-category="temoignages" class="posts"></ul>
 </main>
- codex/set-up-nova-vox-interstellar-static-site-s8siqw
 <footer>
   <p>© 2025 Nova Vox Interstellar</p>
 </footer>
- codex/set-up-nova-vox-interstellar-static-site-3r16vt
-<footer>
-  <p>© 2025 Nova Vox Interstellar</p>
-</footer>
- codex/set-up-nova-vox-interstellar-static-site-g0i3pj
-<footer>
-  <p>© 2025 Nova Vox Interstellar</p>
-</footer>
- main
- main
- main
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add hero and introduction sections to "Édition de la semaine" page
- Add market overview content to "Analyse financière" page
- Add pilot testimonials introduction and imagery
- Add battlefront overview section to "Cartes & batailles" page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b36d12ac20832f87cde5f9e293223a